### PR TITLE
fix: 모달 훅 side effect 수정

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -6,23 +6,22 @@ interface Props {
   modalProps: {
     modalKey: string;
     modalRef: any;
-    closeModal: any;
-    handleModalClick: any;
+    handleClose: any;
+    handleClick: any;
     isOpen: boolean;
   };
   children: ReactNode;
 }
 
 const Modal = ({ modalProps, children }: Props) => {
-  const { modalKey, modalRef, closeModal, handleModalClick, isOpen } =
-    modalProps;
+  const { modalKey, modalRef, handleClose, handleClick, isOpen } = modalProps;
 
   return (
     <dialog
       data-testid={modalKey}
       ref={modalRef}
-      onClick={handleModalClick}
-      onClose={closeModal}
+      onClick={handleClick}
+      onClose={handleClose}
     >
       {isOpen ? children : <></>}
     </dialog>

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -10,40 +10,55 @@ export default function useModal(modalKey: string) {
   const modalRef = useRef<HTMLDialogElement | null>(null);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
+  const hasModalKey = () => searchParams.has(modalKey);
+
   const openModal = () => {
-    setIsOpen(true);
     modalRef.current?.showModal();
+    handleOpen();
+  };
+
+  const handleOpen = () => {
     document.body.style.opacity = "0.7";
     document.body.style.overflow = "hidden";
   };
 
   const closeModal = () => {
-    router.replace(pathname);
+    modalRef.current?.close();
+  };
+
+  const handleClose = () => {
+    hasModalKey() && router.back();
     document.body.style.opacity = "1";
     document.body.style.overflow = "auto";
-    modalRef.current?.close();
-    setIsOpen(false);
   };
 
-  const handleModalClick = (e: any) => {
+  const handleClick = (e: any) => {
     if (e?.target?.nodeName === "DIALOG") {
-      closeModal();
+      setIsOpen(false);
     }
   };
-
-  useEffect(() => {
-    setIsOpen(searchParams.has(modalKey));
-  }, [searchParams]);
 
   useEffect(() => {
     (isOpen ? openModal : closeModal)();
   }, [isOpen]);
 
+  useEffect(() => {
+    setIsOpen(hasModalKey());
+  }, [searchParams.keys]);
+
+  useEffect(() => {
+    if (hasModalKey()) {
+      router.replace(pathname);
+      router.back();
+    }
+  }, []);
+
   return {
     modalKey,
     modalRef,
-    closeModal,
-    handleModalClick,
     isOpen,
+    closeModal,
+    handleClose,
+    handleClick,
   };
 }

--- a/src/services/BreweryService.ts
+++ b/src/services/BreweryService.ts
@@ -2,8 +2,10 @@ import BreweryServiceInterface from "@/types/BreweryServiceInterface";
 import Brewery from "@/types/Brewery";
 
 class BreweryService implements BreweryServiceInterface {
-  private readonly BASE_URL: string =
-    process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3008";
+  // private readonly BASE_URL: string =
+  //   process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3008";
+
+  private readonly BASE_URL: string = "http://localhost:3008";
 
   async fetchBreweriesByInputText(query: string): Promise<Brewery[]> {
     const uri: string = `${this.BASE_URL}?q=${query}`;


### PR DESCRIPTION
- closeModal, openModal의 로직을 여닫는 기능과 후처리를 나눠서 함수 분리
- 모달창을 뒤로 가기로 닫지 않으면 replace 때문에 히스토리가. 쌓임
- router.back으로 수정
- 모달창 연 채로 새로 고침하면 replace로 URI 수정하고 back해서 히스토리 복구